### PR TITLE
Dev build fflip fw

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@ Site-Konfigurationsdateien für Freifunk-Lippe
 
 Die Freifunk-Lippe-Firmware basiert auf den folgenden Gluon Versionen:
 
-* 0.7.12 -> Gluon 2015.1.2
+* 0.7.15 -> Gluon 2015.1.2

--- a/build_fflip_fw.sh
+++ b/build_fflip_fw.sh
@@ -25,9 +25,9 @@ for SITE in "${SITES[@]}"
     cp $DIR/sites/$SITE/site.* $DIR/gluon/site/
     cd gluon
     make update
-    make clean GLUON_TARGET=ar71xx-generic
-    make clean GLUON_TARGET=ar71xx-nand
-    make clean GLUON_TARGET=mpc85xx-generic
+#    make clean GLUON_TARGET=ar71xx-generic # Zum Test auskommentiert
+#    make clean GLUON_TARGET=ar71xx-nand # Zum Test auskommentiert
+#    make clean GLUON_TARGET=mpc85xx-generic # Zum Test auskommentiert
     make -j$CORES GLUON_BRANCH=stable GLUON_TARGET=ar71xx-generic # V=s
     make -j$CORES GLUON_BRANCH=stable GLUON_TARGET=ar71xx-nand # V=s
     make -j$CORES GLUON_BRANCH=stable GLUON_TARGET=mpc85xx-generic # V=s

--- a/build_fflip_fw.sh
+++ b/build_fflip_fw.sh
@@ -4,14 +4,14 @@
 #
 # Created by: Collimas
 # Modified by: Tronde at 2015-10-31
-# Modified by: Collimas at 2015-11-07
+# Modified by: Collimas at 2015-11-14
 
 # Variables ###################################################################
 RELEASE="v2015.1.2"
 DIR=`pwd`
 SITES=(`ls $DIR/sites`)
 # SITES=(BO BS LIP) # Used for testing
-CORES=4 # Specifies the number of jobs (commands) to run simultaneously.
+CORES=3 # Specifies the number of jobs (commands) to run simultaneously.
 SECRET=$DIR/secret
 ###############################################################################
 
@@ -23,25 +23,18 @@ mkdir gluon/site
 for SITE in "${SITES[@]}"
   do
     cp $DIR/sites/$SITE/site.* $DIR/gluon/site/
-    cd gluon
-    make update
-#    make clean GLUON_TARGET=ar71xx-generic # Zum Test auskommentiert
-#    make clean GLUON_TARGET=ar71xx-nand # Zum Test auskommentiert
-#    make clean GLUON_TARGET=mpc85xx-generic # Zum Test auskommentiert
+    cd /home/$USER/fflip-fw/gluon/
     make -j$CORES GLUON_BRANCH=stable GLUON_TARGET=ar71xx-generic # V=s
     make -j$CORES GLUON_BRANCH=stable GLUON_TARGET=ar71xx-nand # V=s
     make -j$CORES GLUON_BRANCH=stable GLUON_TARGET=mpc85xx-generic # V=s
     make manifest GLUON_BRANCH=stable
-    make manifest GLUON_BRANCH=experimental
+    make manifest GLUON_BRANCH=experimental # to be deleted when experimental branch is no longer used
     ./contrib/sign.sh $SECRET images/sysupgrade/stable.manifest
-    ./contrib/sign.sh $SECRET images/sysupgrade/experimental.manifest
+    ./contrib/sign.sh $SECRET images/sysupgrade/experimental.manifest # to be deleted when experimental branch is no longer used
     mkdir -p images/$SITE
     mv -f images/factory images/$SITE/
     mv -f images/sysupgrade images/$SITE/
     rm -rf site/*
 done
-
-cd /$DIR/gluon/images/
-find . -type f -print0 | xargs -0 md5sum > /tmp/MD5SUM; mv /tmp/MD5SUM ./MD5SUM 
 
 exit

--- a/build_fflip_fw.sh
+++ b/build_fflip_fw.sh
@@ -23,7 +23,7 @@ mkdir gluon/site
 for SITE in "${SITES[@]}"
   do
     cp $DIR/sites/$SITE/site.* $DIR/gluon/site/
-    cd /home/$USER/fflip-fw/gluon/
+    cd $DIR/gluon/
     make -j$CORES GLUON_BRANCH=stable GLUON_TARGET=ar71xx-generic # V=s
     make -j$CORES GLUON_BRANCH=stable GLUON_TARGET=ar71xx-nand # V=s
     make -j$CORES GLUON_BRANCH=stable GLUON_TARGET=mpc85xx-generic # V=s

--- a/site.mk.example
+++ b/site.mk.example
@@ -1,11 +1,11 @@
 GLUON_SITE_PACKAGES := \
 	gluon-mesh-batman-adv-14 \
 	gluon-alfred \
-	gluon-announced \
+ 	gluon-announced \
 	gluon-autoupdater \
 	gluon-config-mode-autoupdater \
 	gluon-config-mode-contact-info \
-  gluon-config-mode-core \
+    gluon-config-mode-core \
 	gluon-config-mode-geo-location \
 	gluon-config-mode-hostname \
 	gluon-config-mode-mesh-vpn \
@@ -15,13 +15,13 @@ GLUON_SITE_PACKAGES := \
 	gluon-luci-autoupdater \
 	gluon-luci-portconfig \
 	gluon-luci-private-wifi \
-  gluon-luci-wifi-config \
-  gluon-luci-node-role \
+    gluon-luci-wifi-config \
+    gluon-luci-node-role \
 	gluon-next-node \
 	gluon-mesh-vpn-fastd \
 	gluon-radvd \
 	gluon-wan-dnsmasq \
-  gluon-setup-mode \
+    gluon-setup-mode \
 	gluon-status-page \
 	iwinfo \
 	iptables \
@@ -31,7 +31,7 @@ GLUON_SITE_PACKAGES := \
 
 #    gluon-luci-node-role \   => auch in site-conf auskommentiert
 
-DEFAULT_GLUON_RELEASE := 0.7.12-lip-$(shell date '+%Y%m%d')
+DEFAULT_GLUON_RELEASE := 0.7.15-lip-$(shell date '+%Y%m%d')
 
 # Allow overriding the release number from the command line
 GLUON_RELEASE ?= $(DEFAULT_GLUON_RELEASE)


### PR DESCRIPTION
Habe die Anzahl der Cores auf 3 gesetzt für maximale Performance. 1 Core verbleibt um das System nicht vollends auszulasten.

Habe dem cd in Zeile 26 einen absoluten Pfad hinzugefügt, da ein cd gluon fehlschlägt wenn das Script bereits in dem Verzeichnis arbeitet.

Das make update aus Zeile 27 ist überflüssig, wenn am Beginn des Scipts sowieso alles gelöscht wurde und neu geklont wird.

Die Erzeugung der nutzlosen MD5-Checksumme habe ich herausgenommen.