### PR TITLE
Fixed URL for Update-Mirror update2.freifunk-lippe.de

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,6 @@ Site-Konfigurationsdateien für Freifunk-Lippe
 
 Die Freifunk-Lippe-Firmware basiert auf den folgenden Gluon Versionen:
 
-* 0.8.5 -> Gluon 2016.1.3
+* 0.8.6 -> Gluon 2016.1.3
 
-- Removed netwatch script due to problems with mesh-only nodes
-- Added TX-Power fix to increase transmission range
-- Added time switch for client wifi network
-- Added time switch for throttling the mesh-vpn if necessary 
-
-All external repositories now have been transferred to our own repo on Github to be more safe on changes on the external sites.
-
-- Modified build script for faster building and creating log files
+- Fixed URL for Update-Mirror update2.freifunk-lippe.de

--- a/site.conf.example
+++ b/site.conf.example
@@ -169,7 +169,7 @@ gw08 = {
       stable = {
         name = 'stable',
         -- List of mirrors to fetch images from. IPv6 required!
-        mirrors = {'http://update.fflip/stable/lip/upgrade', 'http://update.freifunk-lippe.de/stable/lip/upgrade', 'http://update2.freifunk-lippe.de/stable/lip/upgrade'},
+        mirrors = {'http://update.fflip/stable/lip/upgrade', 'http://update.freifunk-lippe.de/stable/lip/upgrade', 'http://update2.freifunk-lippe.de/update/stable/lip/upgrade'},
         good_signatures = 2,
         -- List of public keys of maintainers.
         pubkeys = {
@@ -182,7 +182,7 @@ gw08 = {
       beta = {
         name = 'beta',
         -- List of mirrors to fetch images from. IPv6 required!
-        mirrors = {'http://update.fflip/beta/lip/upgrade', 'http://update.freifunk-lippe.de/beta/lip/upgrade', 'http://update2.freifunk-lippe.de/beta/lip/upgrade'},
+        mirrors = {'http://update.fflip/beta/lip/upgrade', 'http://update.freifunk-lippe.de/beta/lip/upgrade', 'http://update2.freifunk-lippe.de/update/beta/lip/upgrade'},
         good_signatures = 1,
         -- List of public keys of maintainers.
         pubkeys = {
@@ -195,7 +195,7 @@ gw08 = {
 	  experimental = {
         name = 'experimental',
         -- List of mirrors to fetch images from. IPv6 required!
-        mirrors = {'http://update.fflip/experimental/lip/upgrade', 'http://update.freifunk-lippe.de/experimental/lip/upgrade', 'http://update2.freifunk-lippe.de/experimental/lip/upgrade'},
+        mirrors = {'http://update.fflip/experimental/lip/upgrade', 'http://update.freifunk-lippe.de/experimental/lip/upgrade', 'http://update2.freifunk-lippe.de/update/experimental/lip/upgrade'},
         good_signatures = 1,
         -- List of public keys of maintainers.
         pubkeys = {

--- a/site.conf.experimental.example
+++ b/site.conf.experimental.example
@@ -169,7 +169,7 @@ gw08 = {
       stable = {
         name = 'stable',
         -- List of mirrors to fetch images from. IPv6 required!
-        mirrors = {'http://update.fflip/stable/lip/upgrade', 'http://update.freifunk-lippe.de/stable/lip/upgrade', 'http://update2.freifunk-lippe.de/stable/lip/upgrade'},
+        mirrors = {'http://update.fflip/stable/lip/upgrade', 'http://update.freifunk-lippe.de/stable/lip/upgrade', 'http://update2.freifunk-lippe.de/update/stable/lip/upgrade'},
         good_signatures = 2,
         -- List of public keys of maintainers.
         pubkeys = {
@@ -182,7 +182,7 @@ gw08 = {
       beta = {
         name = 'beta',
         -- List of mirrors to fetch images from. IPv6 required!
-        mirrors = {'http://update.fflip/beta/lip/upgrade', 'http://update.freifunk-lippe.de/beta/lip/upgrade', 'http://update2.freifunk-lippe.de/beta/lip/upgrade'},
+        mirrors = {'http://update.fflip/beta/lip/upgrade', 'http://update.freifunk-lippe.de/beta/lip/upgrade', 'http://update2.freifunk-lippe.de/update/beta/lip/upgrade'},
         good_signatures = 1,
         -- List of public keys of maintainers.
         pubkeys = {
@@ -195,7 +195,7 @@ gw08 = {
 	  experimental = {
         name = 'experimental',
         -- List of mirrors to fetch images from. IPv6 required!
-        mirrors = {'http://update.fflip/experimental/lip/upgrade', 'http://update.freifunk-lippe.de/experimental/lip/upgrade', 'http://update2.freifunk-lippe.de/experimental/lip/upgrade'},
+        mirrors = {'http://update.fflip/experimental/lip/upgrade', 'http://update.freifunk-lippe.de/experimental/lip/upgrade', 'http://update2.freifunk-lippe.de/update/experimental/lip/upgrade'},
         good_signatures = 1,
         -- List of public keys of maintainers.
         pubkeys = {


### PR DESCRIPTION
Bei der Kontrolle der Logs für update2.freifunk-lippe.de sind mir etliche 404-Fehler aufgefallen.

Ursache ist, dass die Datei `stable.manifest` im Pfad `/stable/lip/upgrade/stable.manifest` erwartet. Die dabei lässt sich jedoch nur unter der URL `/update/stable/lip/upgrade/stable.manifest` abrufen.

Ich habe die URL in den Dateien `site.conf.example` und `site.conf.experimental.example` angepasst.

@collimas Bitte prüfe die Änderungen und gib den Pull-Request frei.