### PR TITLE
Patch mkdir

### DIFF
--- a/build_fflip_fw.sh
+++ b/build_fflip_fw.sh
@@ -33,7 +33,7 @@ build_stable_branch(){
       mv -f output/images/factory output/images/$SITE/
       mv -f output/images/sysupgrade output/images/$SITE/
       rm $DIR/gluon/site/site.*
-      mkdir $DIR/gluon/output/images/logs
+      mkdir -p $DIR/gluon/output/images/logs
       mv $DIR/gluon/make*.log output/images/logs
       echo "Finished building Stable branch."
   done
@@ -54,7 +54,7 @@ build_experimental_branch(){
       mv -f output/images/factory output/images-experimental/$SITE/
       mv -f output/images/sysupgrade output/images-experimental/$SITE/
       rm $DIR/gluon/site/site.*
-      mkdir $DIR/gluon/output/images-experimental/logs
+      mkdir -p $DIR/gluon/output/images-experimental/logs
       mv $DIR/gluon/make*.log output/images-experimental/logs
       echo "Finished building Experimental branch."
   done
@@ -78,7 +78,7 @@ if [ -d "$DIR/gluon" ]
   then
     cd $DIR/gluon
       if [ ! -d "$DIR/gluon/site" ]; then
-        mkdir $DIR/gluon/site
+        mkdir -p $DIR/gluon/site
       fi
     cp $DIR/sites/ff/site.* $DIR/gluon/site/
     make update
@@ -88,7 +88,7 @@ if [ -d "$DIR/gluon" ]
     # If gluon directory does not exist do a fresh clone frome the Freifunk-Gluon Repo
     cd $DIR
     git clone https://github.com/freifunk-gluon/gluon.git gluon # -b $RELEASE
-    mkdir $DIR/gluon/site
+    mkdir -p $DIR/gluon/site
     cp $DIR/sites/ff/site.* $DIR/gluon/site/
     cd $DIR/gluon
     make update

--- a/mksites.sh
+++ b/mksites.sh
@@ -17,12 +17,14 @@ typeset -i i=0
 # Funktionen ##################################################################
 # Erzeuge Configs fuer Stable-Branch
 create_stable_configs(){
-  for SITE in "${SITES[@]}"
-    do
-      sed "s/\<lip\>/$SITE/g" site.conf.example | sed "/ssid/s/\<lippe\>/${SSIDS[i]}/g" > sites/$SITE/site.conf
-      sed "s/\<lip\>/$SITE/g" site.mk.example > sites/$SITE/site.mk
-      i=$i+1
-  done
+  mkdir -p sites
+    for SITE in "${SITES[@]}"
+      do
+        mkdir -p sites/$SITE
+        sed "s/\<lip\>/$SITE/g" site.conf.example | sed "/ssid/s/\<lippe\>/${SSIDS[i]}/g" > sites/$SITE/site.conf
+        sed "s/\<lip\>/$SITE/g" site.mk.example > sites/$SITE/site.mk
+        i=$i+1
+    done
 }
 
 # Sonderfall SSID Freifunk - Stable
@@ -34,12 +36,14 @@ create_stable_ssid_freifunk(){
 
 # Erzeuge Configs fuer Experimental-Branch
 create_experimental_config(){
-  for SITE in "${SITES[@]}"
-    do
-      sed "s/\<lip\>/$SITE/g" site.conf.experimental.example | sed "/ssid/s/\<lippe\>/${SSIDS[i]}/g" > sites-experimental/$SITE/site.conf
-      sed "s/\<lip\>/$SITE/g" site.mk.experimental.example > sites-experimental/$SITE/site.mk
-    i=$i+1
-  done
+  mkdir -p sites-experimental
+    for SITE in "${SITES[@]}"
+      do
+        mkdir -p sites-experimental/$SITE
+        sed "s/\<lip\>/$SITE/g" site.conf.experimental.example | sed "/ssid/s/\<lippe\>/${SSIDS[i]}/g" > sites-experimental/$SITE/site.conf
+        sed "s/\<lip\>/$SITE/g" site.mk.experimental.example > sites-experimental/$SITE/site.mk
+      i=$i+1
+    done
 }
 
 # Sonderfall SSID Freifunk - Experimental


### PR DESCRIPTION
Ich habe mkdir in den genutzten Skripts den Parameter -p hinzugefügt, um unnötige Fehlermeldungen zur Laufzeit zu vermeiden, falls das Verzeichnis schon existiert.