### PR TITLE
Raspberry Pi: Unterstützung für USB-Wifi-Dongles

### DIFF
--- a/site.mk.example
+++ b/site.mk.example
@@ -45,6 +45,13 @@ GLUON_SITE_PACKAGES := \
 	rsk-robinson \
 	gluon-config-mode-domain-select \
 	gluon-scheduled-domain-switch
+	
+# Especially the first Raspberry-Pi does not have a wifi-chip and needs a usb-wifi-dongle
+# This adds USB-Support, USB-Wifi-Support and nano-editor for Raspberry-Pis
+# - D. Marx (github.com/derco0n) 04/2019
+GLUON_raspberry-pi_SITE_PACKAGES := kmod-usb-core kmod-usb2 kmod-rtl8192cu kmod-rt2800-usb kmod-rtl8187 usbutils nano
+GLUON_raspberry-pi-2_SITE_PACKAGES := kmod-usb-core kmod-usb2 kmod-rtl8192cu kmod-rt2800-usb kmod-rtl8187 usbutils nano
+GLUON_raspberry-pi-3_SITE_PACKAGES := kmod-usb-core kmod-usb2 kmod-rtl8192cu kmod-rt2800-usb kmod-rtl8187 usbutils nano
 
 ##	DEFAULT_GLUON_RELEASE
 #		version string to use for images

--- a/site.mk.experimental.example
+++ b/site.mk.experimental.example
@@ -181,6 +181,13 @@ GLUON_WZRHPAG300H_SITE_PACKAGES := $(USB_PACKAGES_BASIC) $(TOOLS_PACKAGES) $(USB
 # mpc85xx-generic
 GLUON_TLWDR4900_SITE_PACKAGES := $(USB_PACKAGES_BASIC) $(TOOLS_PACKAGES) $(USB_PACKAGES_STORAGE)
 
+# Especially the first Raspberry-Pi does not have a wifi-chip and needs a usb-wifi-dongle
+# This adds USB-Support, USB-Wifi-Support and nano-editor for Raspberry-Pis
+# - D. Marx (github.com/derco0n) 04/2019
+GLUON_raspberry-pi_SITE_PACKAGES := kmod-usb-core kmod-usb2 kmod-rtl8192cu kmod-rt2800-usb kmod-rtl8187 usbutils nano
+GLUON_raspberry-pi-2_SITE_PACKAGES := kmod-usb-core kmod-usb2 kmod-rtl8192cu kmod-rt2800-usb kmod-rtl8187 usbutils nano
+GLUON_raspberry-pi-3_SITE_PACKAGES := kmod-usb-core kmod-usb2 kmod-rtl8192cu kmod-rt2800-usb kmod-rtl8187 usbutils nano
+
 ##	DEFAULT_GLUON_RELEASE
 #		version string to use for images
 #		gluon relies on


### PR DESCRIPTION
Das erste Raspberry Pi hat keinen WLAN-Chip.
Die ersten Versuche die FF-Lippe-Firmware auf meinem alten Raspberry mit einem Realtek USB-Wifi-Dongle zum laufen zu bekommen, scheiterten, da kein WLAN ausgestrahlt wurde.

Ich habe mit den Anpassungen erfolgreich die aktuelle gloun-Version kompiliert und auf dem Pi zum laufen gebracht.